### PR TITLE
Fix text json vulnerability

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -37,8 +37,7 @@ jobs:
     - name: Pack NuGet package
       # Use the version determined by semantic-version
       run: |
-        dotnet pack src/KaspiShopClient.Contracts/KaspiShopClient.Contracts.csproj --configuration Release --output . /p:Version=${{ steps.gitversion.outputs.SemVer }}
-        dotnet pack src/KaspiShopClient/KaspiShopClient.csproj --configuration Release --output . /p:Version=${{ steps.gitversion.outputs.SemVer }}
+        dotnet pack KaspiShopClient.nuspec --configuration Release --output . /p:Version=${{ steps.gitversion.outputs.SemVer }}
     - name: Publish NuGet package
       # Only publish if a new version was generated
       if: steps.gitversion.outputs.CommitsSinceVersionSource != '0'

--- a/src/KaspiShopClient.Contracts/KaspiShopClient.Contracts.csproj
+++ b/src/KaspiShopClient.Contracts/KaspiShopClient.Contracts.csproj
@@ -26,7 +26,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="8.0.4" />
+        <PackageReference Include="System.Text.Json" Version="8.0.6" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request makes a minor update to the NuGet packaging workflow and dependency versioning. The main changes are an update to the `System.Text.Json` package version and a switch to packing the NuGet package using the `.nuspec` file instead of the individual project files.

Dependency updates:

* Updated the `System.Text.Json` package version from `8.0.4` to `8.0.6` in `KaspiShopClient.Contracts.csproj` to ensure the latest features and security fixes.

Build and packaging workflow:

* Changed the NuGet packaging step in `.github/workflows/publish-nuget.yml` to use the `KaspiShopClient.nuspec` file for packing, instead of packing the individual project files directly. This can simplify package management and allow for more customization.